### PR TITLE
Replace NASA fetcher with Etsy listing automation

### DIFF
--- a/python-automation-starter/.gitignore
+++ b/python-automation-starter/.gitignore
@@ -1,0 +1,5 @@
+config.json
+output/
+inventory.csv
+__pycache__/
+*.pyc

--- a/python-automation-starter/README.md
+++ b/python-automation-starter/README.md
@@ -1,39 +1,93 @@
-# Python Automation Starter — NASA APOD Fetcher
+# Python Automation Starter — Etsy Lister
 
-This starter project shows how to build and ship a simple **automation script**.  
-It uses the public NASA APOD API to download today's Astronomy Picture of the Day (image + metadata)
-into the `output/` folder. You can run it manually or schedule it to run every day.
-
-> Why this? It's a safe, legal demo that proves the full workflow you'll reuse for client work:
-> config ➜ fetch data ➜ save files ➜ logs ➜ (optional) schedule.
+This starter project now automates **draft listing creation on Etsy**. Provide your
+product catalog in a CSV file and the script will call Etsy's v3 API to create
+listings (optionally uploading product photos) for the items you flag. Start in
+`dry_run` mode to validate everything locally, then switch to live mode once
+you're satisfied with the payloads.
 
 ---
 
-## 🚀 What you get
-- `main.py` — the script you run
-- `config.example.json` — copy this to `config.json` and edit your settings
-- `requirements.txt` — libraries to install
-- `utils/logger.py` — tiny logging helper
-- `output/` — where files are saved
+## 🚀 What it does
+- Loads Etsy API credentials and run settings from `config.json`
+- Reads products from a CSV inventory file
+- Creates draft listings through the Etsy Open API v3
+- Uploads one or more product photos per listing (optional)
+- Logs every step and saves a run summary into `output/`
 
 ---
 
 ## 🧰 Setup (once)
-1. **Install Python** (3.9+ recommended): https://www.python.org/downloads/
-2. **Open a terminal** in this folder (the project folder).
-3. Install libraries:
+1. **Install Python** (3.9+ recommended).
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-4. Make your config:
+3. Copy the example config and update it with your Etsy credentials:
    ```bash
-   copy config.example.json config.json   # Windows (PowerShell: cp config.example.json config.json)
-   cp config.example.json config.json     # macOS / Linux
+   cp config.example.json config.json
    ```
-5. (Optional) Get a free NASA API key: https://api.nasa.gov/  
-   You can use `"DEMO_KEY"` to start (limited rate).
+4. Generate an inventory file. Start from `inventory.example.csv`, replace the
+   sample row with your products, and save it as `inventory.csv` (the default
+   file name referenced in the config).
+5. Place product photos in the folder referenced by `images_dir` (defaults to
+   `images/` relative to this project). Use the `image_filename` column in the
+   CSV to point to each photo.
 
-Edit `config.json` as needed.
+> ℹ️ When you're ready to push listings live, set `"dry_run": false` inside
+> `config.json`. Leave it as `true` while testing to avoid API calls.
+
+---
+
+## ⚙️ Config options (`config.json`)
+| Key | Description |
+| --- | --- |
+| `etsy_api_key` | Your Etsy app's API key. |
+| `etsy_access_token` | OAuth access token for the shop you want to manage. |
+| `shop_id` | Numeric Etsy shop ID. |
+| `inventory_file` | Path to the CSV that defines listings to create. |
+| `images_dir` | Directory where product images live. |
+| `save_dir` | Where logs and run summaries are written (defaults to `output/`). |
+| `default_currency` | ISO currency code for prices (e.g. `USD`). |
+| `default_who_made` | Default maker info (e.g. `i_did`). |
+| `default_when_made` | Production timeframe (e.g. `made_to_order`). |
+| `default_is_supply` | Whether items are supplies by default. |
+| `default_taxonomy_id` | Etsy taxonomy ID applied when a row omits one. |
+| `default_type` | Listing type (`physical` or `download`). |
+| `shipping_profile_id` | Shipping profile to attach (required for physical goods). |
+| `return_policy_id` | Optional return policy ID. |
+| `production_partner_ids` | List of production partner IDs to link. |
+| `should_auto_renew` | Whether Etsy should auto-renew the listing. |
+| `dry_run` | If `true`, skip Etsy API calls and only log what would happen. |
+
+---
+
+## 📄 Inventory CSV format
+The script expects a header row with the following columns (all lowercase):
+
+| Column | Required | Notes |
+| --- | --- | --- |
+| `title` | ✅ | Listing title. |
+| `description` | ✅ | Full listing description. |
+| `price` | ✅ | Decimal amount (uses `default_currency`). |
+| `quantity` | ✅ | Stock level to publish. |
+| `tags` | ⛔️ | Optional comma/semicolon separated tags. |
+| `materials` | ⛔️ | Optional list of materials. |
+| `image_filename` | ⛔️ | Comma/semicolon separated image file names. |
+| `sku` | ⛔️ | Optional SKU. |
+| `taxonomy_id` | ⛔️ | Overrides `default_taxonomy_id` for the row. |
+| `who_made` | ⛔️ | Overrides `default_who_made`. |
+| `when_made` | ⛔️ | Overrides `default_when_made`. |
+| `is_supply` | ⛔️ | Overrides `default_is_supply` (`true`/`false`). |
+| `shipping_profile_id` | ⛔️ | Overrides config value. |
+| `return_policy_id` | ⛔️ | Overrides config value. |
+| `shop_section_id` | ⛔️ | Optional section to assign. |
+| `production_partner_ids` | ⛔️ | Comma/semicolon separated IDs for the row. |
+| `type` | ⛔️ | Overrides `default_type`. |
+
+Additional columns are ignored. Remove rows you do not wish to list yet.
+
+`inventory.example.csv` includes a sample row you can reference.
 
 ---
 
@@ -41,47 +95,45 @@ Edit `config.json` as needed.
 ```bash
 python main.py
 ```
-It will fetch today's APOD, save the image (if available) and metadata JSON into `output/`.
+
+- **Dry run (`dry_run = true`)** — Validates the CSV, builds the payloads, and
+  logs what would be sent to Etsy. No network calls are made.
+- **Live mode (`dry_run = false`)** — Creates draft listings on Etsy and uploads
+  any referenced images.
+
+Each execution writes a JSON summary like `output/etsy_run_YYYYMMDD-HHMMSS.json`
+containing the status of every attempted listing. Review this file (and
+`output/run.log`) after every run.
 
 ---
 
-## ⏰ Schedule it (run daily automatically)
-**Windows (Task Scheduler):**
-1. Open *Task Scheduler* → *Create Basic Task…*
-2. Trigger: *Daily* (choose time)
-3. Action: *Start a Program*
-4. Program/script: `python`
-5. Add arguments: `main.py`
-6. Start in: the **full path** to this folder
+## ⏰ Schedule it (optional)
+Reuse your OS scheduler to run the script automatically—just like the original
+starter project.
 
-**macOS / Linux (cron):**
-1. Find your Python path: `which python` (or `which python3`)
-2. Edit cron: `crontab -e`
-3. Add a daily entry at 8:00 AM:
-   ```
-   0 8 * * * /usr/bin/python3 /full/path/to/main.py >> /full/path/to/output/cron.log 2>&1
-   ```
+**Windows (Task Scheduler)**
+1. *Create Basic Task…*
+2. Trigger: choose when it should run (daily, weekly, etc.)
+3. Action: *Start a Program* → `python`
+4. Add arguments: `main.py`
+5. Start in: the **full path** to this folder
 
----
-
-## 🧪 Customize for clients
-Replace the NASA fetch step with:
-- Calling a public API your client uses
-- Reading a CSV/Excel, cleaning data, exporting a report
-- Hitting a SaaS API and generating a PDF summary
-
-Keep the **structure**, swap the **task**. That's it.
-
----
-
-## 📦 Hand-off to a client
-- Zip this folder or push it to a private GitHub repo
-- Include your `README.md` and (optionally) a short Loom video showing how to run it
-- Never include secrets in your repo; keep them only in `config.json` (gitignored by default in real projects)
+**macOS / Linux (cron)**
+```cron
+0 8 * * * /usr/bin/python3 /full/path/to/main.py >> /full/path/to/output/cron.log 2>&1
+```
+Adjust the schedule and Python path as needed.
 
 ---
 
 ## ❓ FAQ
-- **Do I need a NASA key?** You can start with `DEMO_KEY`, but it's rate-limited. Get your own free key for reliability.
-- **Where are files saved?** In `output/` (create this folder if it doesn't exist).
-- **Can I change the time it runs?** Yes—adjust Task Scheduler or cron.
+- **Can I test without real API credentials?** Yes—leave `dry_run` enabled. The
+  script will parse the CSV, build payloads, and log them locally.
+- **How do I get required IDs?** Use Etsy's admin or API to look up taxonomy,
+  shipping profile, section, and production partner IDs. Fill them in either in
+  `config.json` or directly in the CSV.
+- **Where are files saved?** Logs and run summaries live in the directory
+  defined by `save_dir` (defaults to `output/`).
+- **Can I reuse this for other marketplaces?** Absolutely. Swap out the Etsy
+  API calls with the marketplace you need, but keep the overall structure: load
+  config → read inventory → perform API actions → log results.

--- a/python-automation-starter/config.example.json
+++ b/python-automation-starter/config.example.json
@@ -1,5 +1,19 @@
 {
-  "nasa_api_key": "DEMO_KEY",
+  "etsy_api_key": "YOUR_ETSY_API_KEY",
+  "etsy_access_token": "YOUR_OAUTH_ACCESS_TOKEN",
+  "shop_id": 12345678,
+  "inventory_file": "inventory.csv",
+  "images_dir": "images",
   "save_dir": "output",
-  "download_hd": false
+  "default_currency": "USD",
+  "default_who_made": "i_did",
+  "default_when_made": "made_to_order",
+  "default_is_supply": false,
+  "default_taxonomy_id": null,
+  "default_type": "physical",
+  "shipping_profile_id": null,
+  "return_policy_id": null,
+  "production_partner_ids": [],
+  "should_auto_renew": false,
+  "dry_run": true
 }

--- a/python-automation-starter/inventory.example.csv
+++ b/python-automation-starter/inventory.example.csv
@@ -1,0 +1,2 @@
+sku,title,description,price,quantity,tags,materials,image_filename,taxonomy_id,who_made,when_made,is_supply,shipping_profile_id,return_policy_id,shop_section_id,production_partner_ids,type
+SKU-1001,"Handmade Ceramic Mug","A hand-thrown ceramic mug with a speckled glaze and ergonomic handle. Holds 12 oz.",24.00,5,"ceramic;coffee mug;gift","stoneware clay;glaze","mug-front.jpg;mug-side.jpg",1234567890,i_did,2020_2023,false,987654321,null,null,,physical

--- a/python-automation-starter/main.py
+++ b/python-automation-starter/main.py
@@ -1,86 +1,477 @@
-import os
-import json
-import requests
+import csv
 import datetime
+import json
+import mimetypes
+import os
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Dict, List, Optional
+
+import requests
+
 from utils.logger import get_logger
 
-# ---------- Load config ----------
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
-DEFAULTS = {
-    "nasa_api_key": "DEMO_KEY",     # Replace with your own key from https://api.nasa.gov/
-    "save_dir": "output",           # Where to save files
-    "download_hd": False            # Try HD image when available
+BASE_DIR = os.path.dirname(__file__)
+CONFIG_PATH = os.path.join(BASE_DIR, "config.json")
+API_BASE = "https://openapi.etsy.com/v3/application"
+REQUEST_TIMEOUT = 30
+
+DEFAULTS: Dict[str, Any] = {
+    "etsy_api_key": "",
+    "etsy_access_token": "",
+    "shop_id": None,
+    "inventory_file": "inventory.csv",
+    "images_dir": "images",
+    "save_dir": "output",
+    "default_currency": "USD",
+    "default_who_made": "i_did",
+    "default_when_made": "made_to_order",
+    "default_is_supply": False,
+    "default_taxonomy_id": None,
+    "default_type": "physical",
+    "shipping_profile_id": None,
+    "return_policy_id": None,
+    "production_partner_ids": [],
+    "should_auto_renew": False,
+    "dry_run": True,
 }
 
-def load_config():
+
+# ---------- Config ----------
+def load_config() -> Dict[str, Any]:
     cfg = DEFAULTS.copy()
     if os.path.exists(CONFIG_PATH):
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             user_cfg = json.load(f)
-        cfg.update(user_cfg or {})
+        if user_cfg:
+            cfg.update(user_cfg)
     return cfg
 
-# ---------- APOD fetch ----------
-def fetch_apod(api_key: str, date: str = None):
-    """Fetch NASA APOD metadata (and image URL if present)."""
-    url = "https://api.nasa.gov/planetary/apod"
-    params = {"api_key": api_key}
-    if date:
-        params["date"] = date  # YYYY-MM-DD
-    resp = requests.get(url, params=params, timeout=20)
-    resp.raise_for_status()
-    return resp.json()
 
-def download_file(url: str, dest_path: str):
-    r = requests.get(url, stream=True, timeout=60)
-    r.raise_for_status()
-    with open(dest_path, "wb") as f:
-        for chunk in r.iter_content(chunk_size=8192):
-            if chunk:
-                f.write(chunk)
+def make_absolute(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+    if os.path.isabs(path):
+        return os.path.normpath(path)
+    return os.path.normpath(os.path.join(BASE_DIR, path))
 
-def main():
+
+TRUE_VALUES = {"true", "1", "yes", "y"}
+FALSE_VALUES = {"false", "0", "no", "n"}
+
+
+def parse_optional_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None or value == "":
+        return None
+    val = value.strip().lower()
+    if val in TRUE_VALUES:
+        return True
+    if val in FALSE_VALUES:
+        return False
+    raise ValueError(f"Cannot parse boolean value from '{value}'")
+
+
+def parse_optional_int(value: Optional[str]) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def split_list_field(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    parts = re.split(r"[;,]", value)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def parse_price(value: Optional[str]) -> Decimal:
+    if not value:
+        raise ValueError("Price is required")
+    try:
+        price = Decimal(value)
+    except (InvalidOperation, TypeError) as exc:
+        raise ValueError(f"Invalid price '{value}'") from exc
+    if price <= 0:
+        raise ValueError("Price must be greater than zero")
+    return price.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def price_to_amount(price: Decimal) -> int:
+    return int((price * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def resolve_image_path(filename: str, images_dir: Optional[str]) -> str:
+    filename = filename.strip()
+    if os.path.isabs(filename):
+        return os.path.normpath(filename)
+    base_dir = images_dir or BASE_DIR
+    return os.path.normpath(os.path.join(base_dir, filename))
+
+
+# ---------- Inventory parsing ----------
+def read_inventory(csv_path: str, images_dir: Optional[str], logger) -> List[Dict[str, Any]]:
+    products: List[Dict[str, Any]] = []
+    if not os.path.exists(csv_path):
+        logger.error("Inventory file not found: %s", csv_path)
+        return products
+
+    with open(csv_path, "r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        for line_no, row in enumerate(reader, start=2):
+            title = (row.get("title") or "").strip()
+            if not title:
+                logger.warning("Row %s is missing a title. Skipping.", line_no)
+                continue
+
+            description = (row.get("description") or "").strip()
+            if not description:
+                logger.error("Row %s ('%s') is missing a description. Skipping.", line_no, title)
+                continue
+
+            try:
+                price = parse_price(row.get("price"))
+            except ValueError as exc:
+                logger.error("Row %s ('%s') has an invalid price: %s", line_no, title, exc)
+                continue
+
+            try:
+                quantity = int((row.get("quantity") or "0").strip())
+            except ValueError:
+                logger.error("Row %s ('%s') has an invalid quantity. Skipping.", line_no, title)
+                continue
+            if quantity < 0:
+                logger.error("Row %s ('%s') has a negative quantity. Skipping.", line_no, title)
+                continue
+
+            product: Dict[str, Any] = {
+                "title": title,
+                "description": description,
+                "price": price,
+                "price_amount": price_to_amount(price),
+                "quantity": quantity,
+                "tags": split_list_field(row.get("tags")),
+                "materials": split_list_field(row.get("materials")),
+                "sku": (row.get("sku") or "").strip() or None,
+                "taxonomy_id": None,
+                "who_made": (row.get("who_made") or "").strip() or None,
+                "when_made": (row.get("when_made") or "").strip() or None,
+                "is_supply": None,
+                "shipping_profile_id": None,
+                "return_policy_id": None,
+                "shop_section_id": None,
+                "production_partner_ids": [],
+                "type": (row.get("type") or "").strip() or None,
+                "image_paths": [],
+            }
+
+            try:
+                product["taxonomy_id"] = parse_optional_int((row.get("taxonomy_id") or "").strip() or None)
+            except ValueError:
+                logger.warning("Row %s ('%s') has an invalid taxonomy_id. Ignoring value.", line_no, title)
+
+            try:
+                parsed_supply = parse_optional_bool(row.get("is_supply"))
+            except ValueError:
+                logger.warning("Row %s ('%s') has an invalid is_supply value. Ignoring value.", line_no, title)
+                parsed_supply = None
+            product["is_supply"] = parsed_supply
+
+            for key in ("shipping_profile_id", "return_policy_id", "shop_section_id"):
+                try:
+                    product[key] = parse_optional_int((row.get(key) or "").strip() or None)
+                except ValueError:
+                    logger.warning("Row %s ('%s') has an invalid %s. Ignoring value.", line_no, title, key)
+
+            partner_values: List[int] = []
+            if row.get("production_partner_ids"):
+                for raw in split_list_field(row.get("production_partner_ids")):
+                    try:
+                        partner_values.append(int(raw))
+                    except ValueError:
+                        logger.warning(
+                            "Row %s ('%s') has an invalid production_partner_id '%s'. Ignoring value.",
+                            line_no,
+                            title,
+                            raw,
+                        )
+            product["production_partner_ids"] = partner_values
+
+            image_field = row.get("image_filename") or row.get("images")
+            if image_field:
+                paths: List[str] = []
+                for raw_name in split_list_field(image_field):
+                    resolved = resolve_image_path(raw_name, images_dir)
+                    if os.path.exists(resolved):
+                        paths.append(resolved)
+                    else:
+                        logger.warning(
+                            "Row %s ('%s') references missing image: %s",
+                            line_no,
+                            title,
+                            resolved,
+                        )
+                product["image_paths"] = paths
+
+            products.append(product)
+    return products
+
+
+# ---------- Etsy client ----------
+class EtsyClient:
+    def __init__(self, api_key: str, access_token: str, shop_id: Any, logger) -> None:
+        if not api_key:
+            raise ValueError("Missing 'etsy_api_key' in config")
+        if not access_token:
+            raise ValueError("Missing 'etsy_access_token' in config")
+        if not shop_id:
+            raise ValueError("Missing 'shop_id' in config")
+
+        self.shop_id = str(shop_id)
+        self.logger = logger
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "x-api-key": api_key,
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json",
+            }
+        )
+
+    @staticmethod
+    def _unwrap(data: Any) -> Dict[str, Any]:
+        if isinstance(data, dict) and "data" in data and isinstance(data["data"], dict):
+            return data["data"]
+        if isinstance(data, dict):
+            return data
+        raise ValueError("Unexpected response format from Etsy API")
+
+    def create_draft_listing(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{API_BASE}/shops/{self.shop_id}/listings"
+        request_payload = dict(payload)
+        request_payload.setdefault("state", "draft")
+        response = self.session.post(url, json=request_payload, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        data = self._unwrap(response.json())
+        return data
+
+    def upload_images(self, listing_id: Any, image_paths: List[str]) -> List[Any]:
+        if not image_paths:
+            return []
+
+        uploaded: List[Any] = []
+        for position, path in enumerate(image_paths, start=1):
+            if not os.path.exists(path):
+                self.logger.warning("Image path no longer exists: %s", path)
+                continue
+            mime_type = mimetypes.guess_type(path)[0] or "application/octet-stream"
+            url = f"{API_BASE}/shops/{self.shop_id}/listings/{listing_id}/images"
+            with open(path, "rb") as fh:
+                files = {"image": (os.path.basename(path), fh, mime_type)}
+                data = {"rank": position}
+                response = self.session.post(url, data=data, files=files, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            payload = self._unwrap(response.json())
+            uploaded.append(payload.get("listing_image_id") or payload.get("image_id"))
+        return uploaded
+
+
+# ---------- Payload building ----------
+def resolve_listing_value(product: Dict[str, Any], config: Dict[str, Any], key: str) -> Any:
+    if product.get(key) is not None:
+        return product[key]
+    return config.get(key)
+
+
+def build_listing_payload(product: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "quantity": product["quantity"],
+        "title": product["title"],
+        "description": product["description"],
+        "who_made": product.get("who_made") or config["default_who_made"],
+        "when_made": product.get("when_made") or config["default_when_made"],
+        "is_supply": (
+            product["is_supply"]
+            if product["is_supply"] is not None
+            else config["default_is_supply"]
+        ),
+        "type": product.get("type") or config["default_type"],
+        "should_auto_renew": config.get("should_auto_renew", False),
+        "state": "draft",
+        "price": {
+            "amount": product["price_amount"],
+            "currency_code": config.get("default_currency", "USD"),
+        },
+    }
+
+    taxonomy_id = product.get("taxonomy_id") or config.get("default_taxonomy_id")
+    if taxonomy_id:
+        payload["taxonomy_id"] = taxonomy_id
+
+    for list_field in ("tags", "materials"):
+        if product[list_field]:
+            payload[list_field] = product[list_field]
+
+    for field in ("shipping_profile_id", "return_policy_id", "shop_section_id"):
+        value = resolve_listing_value(product, config, field)
+        if value:
+            payload[field] = value
+
+    partners = product.get("production_partner_ids") or config.get("production_partner_ids")
+    if partners:
+        payload["production_partner_ids"] = partners
+
+    if product.get("sku"):
+        payload.setdefault("inventory", {"products": []})
+        payload["inventory"]["products"].append(
+            {
+                "sku": product["sku"],
+                "property_values": [],
+                "offerings": [
+                    {
+                        "price": {
+                            "amount": product["price_amount"],
+                            "currency_code": config.get("default_currency", "USD"),
+                        },
+                        "quantity": product["quantity"],
+                        "is_enabled": True,
+                    }
+                ],
+            }
+        )
+
+    return payload
+
+
+def save_run_summary(results: List[Dict[str, Any]], dry_run: bool, save_dir: str) -> str:
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    summary = {
+        "run_at": datetime.datetime.now().isoformat(),
+        "dry_run": dry_run,
+        "results": results,
+    }
+    os.makedirs(save_dir, exist_ok=True)
+    path = os.path.join(save_dir, f"etsy_run_{timestamp}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+    return path
+
+
+# ---------- Main ----------
+def main() -> None:
     logger = get_logger()
-    cfg = load_config()
-    save_dir = os.path.join(os.path.dirname(__file__), cfg["save_dir"])
+    config = load_config()
+
+    inventory_path = make_absolute(config.get("inventory_file")) or ""
+    images_dir = make_absolute(config.get("images_dir"))
+    save_dir = make_absolute(config.get("save_dir")) or os.path.join(BASE_DIR, "output")
     os.makedirs(save_dir, exist_ok=True)
 
-    # Use today's date
-    today = datetime.date.today().isoformat()
-    try:
-        data = fetch_apod(cfg["nasa_api_key"], date=today)
-    except Exception as e:
-        logger.exception("Failed to fetch APOD: %s", e)
+    products = read_inventory(inventory_path, images_dir, logger)
+    if not products:
+        logger.warning("No valid products found. Nothing to do.")
         return
 
-    # Save metadata JSON
-    meta_name = f"apod_{today}.json"
-    meta_path = os.path.join(save_dir, meta_name)
-    with open(meta_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
-    logger.info("Saved metadata: %s", meta_path)
+    results: List[Dict[str, Any]] = []
+    client: Optional[EtsyClient] = None
 
-    # If it's an image, download it
-    media_type = data.get("media_type")
-    img_url = None
-    if media_type == "image":
-        if cfg.get("download_hd") and data.get("hdurl"):
-            img_url = data["hdurl"]
-        else:
-            img_url = data.get("url")
-
-    if img_url:
-        # Guess filename extension
-        ext = os.path.splitext(img_url.split("?")[0])[1] or ".jpg"
-        img_name = f"apod_{today}{ext}"
-        img_path = os.path.join(save_dir, img_name)
+    if not config.get("dry_run", True):
         try:
-            download_file(img_url, img_path)
-            logger.info("Saved image: %s", img_path)
-        except Exception as e:
-            logger.exception("Failed to download image: %s", e)
-    else:
-        logger.info("No downloadable image for today (media_type=%s).", media_type)
+            client = EtsyClient(
+                api_key=config.get("etsy_api_key", ""),
+                access_token=config.get("etsy_access_token", ""),
+                shop_id=config.get("shop_id"),
+                logger=logger,
+            )
+        except ValueError as exc:
+            logger.error("Configuration error: %s", exc)
+            return
+
+    for product in products:
+        try:
+            payload = build_listing_payload(product, config)
+        except Exception as exc:  # Catch unexpected data issues per row
+            logger.exception("Failed to build payload for '%s': %s", product["title"], exc)
+            results.append(
+                {
+                    "title": product["title"],
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+            continue
+
+        if config.get("dry_run", True):
+            logger.info(
+                "Dry run: would create listing '%s' (qty=%s, price=%s %s)",
+                product["title"],
+                product["quantity"],
+                product["price"],
+                config.get("default_currency", "USD"),
+            )
+            results.append(
+                {
+                    "title": product["title"],
+                    "status": "dry_run",
+                    "quantity": product["quantity"],
+                    "price": str(product["price"]),
+                }
+            )
+            continue
+
+        if client is None:
+            logger.error("Etsy client is not initialized. Aborting run.")
+            return
+
+        try:
+            listing_data = client.create_draft_listing(payload)
+            listing_id = listing_data.get("listing_id") or listing_data.get("id")
+            logger.info("Created Etsy listing %s for '%s'", listing_id, product["title"])
+            entry: Dict[str, Any] = {
+                "title": product["title"],
+                "status": "created",
+                "listing_id": listing_id,
+                "quantity": product["quantity"],
+                "price": str(product["price"]),
+            }
+
+            if product.get("image_paths"):
+                try:
+                    uploaded = client.upload_images(listing_id, product["image_paths"])
+                    entry["images_uploaded"] = uploaded
+                    logger.info(
+                        "Uploaded %s image(s) for listing %s", len(uploaded), listing_id
+                    )
+                except requests.HTTPError as exc:
+                    logger.exception(
+                        "Failed to upload images for listing %s ('%s'): %s",
+                        listing_id,
+                        product["title"],
+                        exc,
+                    )
+                    entry["image_error"] = str(exc)
+            results.append(entry)
+        except requests.HTTPError as exc:
+            logger.exception("Etsy API error for '%s': %s", product["title"], exc)
+            results.append(
+                {
+                    "title": product["title"],
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+        except Exception as exc:
+            logger.exception("Unexpected error for '%s': %s", product["title"], exc)
+            results.append(
+                {
+                    "title": product["title"],
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+
+    summary_path = save_run_summary(results, config.get("dry_run", True), save_dir)
+    logger.info("Run summary saved to %s", summary_path)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the NASA demo with an Etsy draft-listing automation script that reads a CSV inventory, calls the Etsy API, and optionally uploads listing images
- document the new workflow, required configuration, and CSV format in the README and provide updated example files
- ignore local config/output/inventory files so real credentials and artifacts stay out of version control

## Testing
- python -m compileall .
- python main.py


------
https://chatgpt.com/codex/tasks/task_e_68d0a02ee8a483299861d95e97e8e839